### PR TITLE
Adding a nifi processor to convert GetOPCNodeList output to tempus attributes

### DIFF
--- a/nifi-tempus-processors/src/main/java/com/hashmapinc/tempus/nifi/processors/OpcToTempusAttributes.java
+++ b/nifi-tempus-processors/src/main/java/com/hashmapinc/tempus/nifi/processors/OpcToTempusAttributes.java
@@ -1,0 +1,223 @@
+package com.hashmapinc.tempus.nifi.processors;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import org.apache.nifi.annotation.behavior.*;
+import org.apache.nifi.annotation.documentation.CapabilityDescription;
+import org.apache.nifi.annotation.documentation.Tags;
+import org.apache.nifi.annotation.lifecycle.OnScheduled;
+import org.apache.nifi.components.PropertyDescriptor;
+import org.apache.nifi.flowfile.FlowFile;
+import org.apache.nifi.logging.ComponentLog;
+import org.apache.nifi.processor.*;
+import org.apache.nifi.processor.exception.ProcessException;
+import org.apache.nifi.processor.io.InputStreamCallback;
+import org.apache.nifi.processor.util.StandardValidators;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.util.*;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Collectors;
+
+
+/**
+ * Created by Shubham Gupta on 08-03-2018.
+ */
+
+@Tags({"Tempus", "OPC-UA", "Json", "Attributes"})
+@CapabilityDescription("Read output flowfile from GetOPCNodeList processor and convert the data to Tempus Device/Gateway Attributes Json format.")
+@ReadsAttributes({@ReadsAttribute(attribute="", description="")})
+@WritesAttributes({@WritesAttribute(attribute="", description="")})
+@InputRequirement(InputRequirement.Requirement.INPUT_REQUIRED)
+public class OpcToTempusAttributes extends AbstractProcessor {
+    private static ObjectMapper mapper = new ObjectMapper();
+
+    public static final PropertyDescriptor ATTRIBUTE_JSON_FORMAT = new PropertyDescriptor
+            .Builder().name("Attribute Json Format")
+            .displayName("Attribute Json Format")
+            .description("Select the type of attribute Json you want")
+            .defaultValue("Gateway Json")
+            .allowableValues("Gateway Json", "Device Json")
+            .required(true)
+            .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
+            .build();
+
+    public static final Relationship SUCCESS = new Relationship.Builder()
+            .name("Success")
+            .description("Successfully transferred attributes.")
+            .build();
+
+    public static final Relationship FAILURE = new Relationship.Builder()
+            .name("Failure")
+            .description("Failed")
+            .build();
+
+    private List<PropertyDescriptor> descriptors;
+
+    private Set<Relationship> relationships;
+
+    @Override
+    protected void init(final ProcessorInitializationContext context) {
+        final List<PropertyDescriptor> descriptors = new ArrayList<PropertyDescriptor>();
+        descriptors.add(ATTRIBUTE_JSON_FORMAT);
+        this.descriptors = Collections.unmodifiableList(descriptors);
+
+        final Set<Relationship> relationships = new HashSet<Relationship>();
+        relationships.add(SUCCESS);
+        relationships.add(FAILURE);
+
+        this.relationships = Collections.unmodifiableSet(relationships);
+    }
+
+    @Override
+    public Set<Relationship> getRelationships() {
+        return this.relationships;
+    }
+
+    @Override
+    public final List<PropertyDescriptor> getSupportedPropertyDescriptors() {
+        return descriptors;
+    }
+
+    @OnScheduled
+    public void onScheduled(final ProcessContext context) {
+
+    }
+
+    @Override
+    public void onTrigger(final ProcessContext context, final ProcessSession session) throws ProcessException {
+        ComponentLog logger = getLogger();
+        FlowFile flowFile = session.get();
+
+        if ( flowFile == null ) {
+            logger.error("Flow file is null");
+            return;
+        }
+
+        // Initialize  response variable
+        final AtomicReference<List<String>> opcuaListData = new AtomicReference<>();
+
+        // Read opc data from flow file content
+        session.read(flowFile, new InputStreamCallback() {
+            @Override
+            public void process(InputStream in) throws IOException {
+
+                try{
+                    List<String> tagname = new BufferedReader(new InputStreamReader(in)).lines().collect(Collectors.toList());
+                    opcuaListData.set(tagname);
+                }catch (Exception e) {
+                    // TODO Auto-generated catch block
+                    e.printStackTrace();
+                    logger.error("Failed to read");
+                }
+            }
+        });
+
+        int recursiveDepth = Integer.parseInt(flowFile.getAttribute("recursiveDepth"));
+        StringBuilder opcuaData = removeUnnecessaryOpcData(opcuaListData.get(), recursiveDepth);
+
+        if (opcuaData.length() == 0) {
+            logger.error("No useful data extracted");
+            return;
+        }
+
+        String nodesData[] = opcuaData.toString().split("\\r?\\n");
+        JsonNode jsonNode = null;
+
+        if (context.getProperty(ATTRIBUTE_JSON_FORMAT).getValue().equals("Gateway Json")) {
+            jsonNode = transformOpcDataToGatewayAttributes(nodesData);
+        } else {
+            jsonNode = transformOpcDataToDeviceAttributes(nodesData);
+        }
+
+        if (jsonNode != null) {
+            try {
+                final String outData = mapper.writeValueAsString(jsonNode);
+                session.putAttribute(flowFile, "mime.type", "application/json");
+                flowFile = session.write(flowFile, out -> out.write(outData.getBytes()));
+                session.transfer(flowFile, SUCCESS);
+            } catch (JsonProcessingException e) {
+                e.printStackTrace();
+                session.transfer(flowFile, FAILURE);
+            }
+        } else {
+            logger.error("OPCUA data generated is null");
+            session.transfer(flowFile, FAILURE);
+        }
+    }
+
+    private JsonNode transformOpcDataToGatewayAttributes(String[]  nodesData) {
+        JsonNode jsonNode = mapper.createObjectNode();
+        JsonNode jsonValue;
+        for (int i = 0; i < nodesData.length; i++) {
+            jsonValue = mapper.createObjectNode();
+            String key = extractKey(nodesData[i]);
+            String value = extractValue(nodesData[i]);
+
+            ((ObjectNode) jsonValue).put(value, false);
+            while (true) {
+                i++;
+                if (i >= nodesData.length) {
+                    break;
+                }
+
+                String keyNext = extractKey(nodesData[i]);
+                if (key.equals(keyNext)) {
+                    ((ObjectNode) jsonValue).put(extractValue(nodesData[i]), false);
+                } else {
+                    i--;
+                    break;
+                }
+            }
+            ((ObjectNode) jsonValue).put("channelId", key);
+            ((ObjectNode) jsonNode).set(key, jsonValue);
+        }
+        return jsonNode;
+    }
+
+    private JsonNode transformOpcDataToDeviceAttributes(String[]  nodesData) {
+        JsonNode jsonNode = mapper.createObjectNode();
+        String key = extractKey(nodesData[0]);
+        ((ObjectNode) jsonNode).put("channelId", key);
+        for (int i = 0; i < nodesData.length; i++) {
+            String value = extractValue(nodesData[i]);
+            ((ObjectNode) jsonNode).put(value, false);
+        }
+        return jsonNode;
+    }
+
+    private StringBuilder removeUnnecessaryOpcData(List<String> opcuaListData, int recursiveDepth) {
+        StringBuilder opcuaData = new StringBuilder();
+        for (int i = 0; i < opcuaListData.size(); i++) {
+            if (opcuaListData.get(i).contains("nsu")) {
+                continue;
+            }
+            String nodes[] = opcuaListData.get(i).split("\\.");
+            if (nodes.length < recursiveDepth) {
+                continue;
+            }
+            opcuaData.append(opcuaListData.get(i) + System.getProperty("line.separator"));
+        }
+        return opcuaData;
+    }
+
+    private String extractKey(String nodeData) {
+        String keyValue[] = nodeData.split("\\.");
+        String key = "";
+        for (int j = 0; j < keyValue.length-1; j++) {
+            key = key + keyValue[j].replace("- ", "") + ".";
+        }
+        key = key.substring(0, key.length() - 1);
+        return key;
+    }
+
+    private String extractValue(String nodeData) {
+        String keyValue[] = nodeData.split("\\.");
+        return keyValue[keyValue.length - 1];
+    }
+}

--- a/nifi-tempus-processors/src/main/java/com/hashmapinc/tempus/nifi/processors/OpcToTempusAttributes.java
+++ b/nifi-tempus-processors/src/main/java/com/hashmapinc/tempus/nifi/processors/OpcToTempusAttributes.java
@@ -199,6 +199,9 @@ public class OpcToTempusAttributes extends AbstractProcessor {
             if (nodes.length < recursiveDepth) {
                 continue;
             }
+            if (nodes[nodes.length - 1].startsWith("_")) {
+                continue;
+            }
             opcuaData.append(opcuaListData.get(i) + System.getProperty("line.separator"));
         }
         return opcuaData;

--- a/nifi-tempus-processors/src/main/java/com/hashmapinc/tempus/nifi/processors/OpcToTempusAttributes.java
+++ b/nifi-tempus-processors/src/main/java/com/hashmapinc/tempus/nifi/processors/OpcToTempusAttributes.java
@@ -119,7 +119,9 @@ public class OpcToTempusAttributes extends AbstractProcessor {
         });
 
         int recursiveDepth = Integer.parseInt(flowFile.getAttribute("recursiveDepth"));
-        StringBuilder opcuaData = removeUnnecessaryOpcData(opcuaListData.get(), recursiveDepth);
+        String startingNode = flowFile.getAttribute("startNode");
+
+        StringBuilder opcuaData = removeUnnecessaryOpcData(opcuaListData.get(), recursiveDepth, startingNode);
 
         if (opcuaData.length() == 0) {
             logger.error("No useful data extracted");
@@ -189,14 +191,16 @@ public class OpcToTempusAttributes extends AbstractProcessor {
         return jsonNode;
     }
 
-    private StringBuilder removeUnnecessaryOpcData(List<String> opcuaListData, int recursiveDepth) {
+    private StringBuilder removeUnnecessaryOpcData(List<String> opcuaListData, int recursiveDepth, String startingNode) {
         StringBuilder opcuaData = new StringBuilder();
         for (int i = 0; i < opcuaListData.size(); i++) {
             if (opcuaListData.get(i).contains("nsu")) {
                 continue;
             }
             String nodes[] = opcuaListData.get(i).split("\\.");
-            if (nodes.length < recursiveDepth) {
+            if (startingNode != null && nodes.length - 2 < recursiveDepth) {
+                continue;
+            } else if (nodes.length < recursiveDepth) {
                 continue;
             }
             if (nodes[nodes.length - 1].startsWith("_")) {

--- a/nifi-tempus-processors/src/main/java/com/hashmapinc/tempus/nifi/processors/OpcToTempusAttributes.java
+++ b/nifi-tempus-processors/src/main/java/com/hashmapinc/tempus/nifi/processors/OpcToTempusAttributes.java
@@ -174,7 +174,6 @@ public class OpcToTempusAttributes extends AbstractProcessor {
                     break;
                 }
             }
-            ((ObjectNode) jsonValue).put("channelId", key);
             ((ObjectNode) jsonNode).set(key, jsonValue);
         }
         return jsonNode;
@@ -183,7 +182,6 @@ public class OpcToTempusAttributes extends AbstractProcessor {
     private JsonNode transformOpcDataToDeviceAttributes(String[]  nodesData) {
         JsonNode jsonNode = mapper.createObjectNode();
         String key = extractKey(nodesData[0]);
-        ((ObjectNode) jsonNode).put("channelId", key);
         for (int i = 0; i < nodesData.length; i++) {
             String value = extractValue(nodesData[i]);
             ((ObjectNode) jsonNode).put(value, false);

--- a/nifi-tempus-processors/src/main/java/com/hashmapinc/tempus/nifi/processors/TempusToNodeList.java
+++ b/nifi-tempus-processors/src/main/java/com/hashmapinc/tempus/nifi/processors/TempusToNodeList.java
@@ -1,0 +1,182 @@
+package com.hashmapinc.tempus.nifi.processors;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import org.apache.nifi.annotation.behavior.*;
+import org.apache.nifi.annotation.documentation.CapabilityDescription;
+import org.apache.nifi.annotation.documentation.Tags;
+import org.apache.nifi.annotation.lifecycle.OnScheduled;
+import org.apache.nifi.components.PropertyDescriptor;
+import org.apache.nifi.flowfile.FlowFile;
+import org.apache.nifi.logging.ComponentLog;
+import org.apache.nifi.processor.*;
+import org.apache.nifi.processor.exception.ProcessException;
+import org.apache.nifi.processor.io.InputStreamCallback;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.nifi.processor.util.StandardValidators;
+
+import java.io.*;
+import java.util.*;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * Created by Shubham Gupta on 14-03-2018.
+ */
+
+@Tags({"Tempus", "OPC-UA", "Node-List", "Attributes"})
+@CapabilityDescription("Read the json data with attributes names and values. Convert the Json data to OPC node list which will be input GetOpcData.")
+@ReadsAttributes({@ReadsAttribute(attribute="", description="")})
+@WritesAttributes({@WritesAttribute(attribute="", description="")})
+@InputRequirement(InputRequirement.Requirement.INPUT_REQUIRED)
+public class TempusToNodeList extends AbstractProcessor {
+    private static ObjectMapper mapper = new ObjectMapper();
+
+    public static final PropertyDescriptor STORAGE_FILE_NAME = new PropertyDescriptor
+            .Builder().name("File Path")
+            .displayName("File Path")
+            .description("Provide the path of file where the List of Nodes is stored.")
+            .required(true)
+            .addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
+            .build();
+
+    public static final Relationship SUCCESS = new Relationship.Builder()
+            .name("Success")
+            .description("Successfully transferred attributes.")
+            .build();
+
+    public static final Relationship FAILURE = new Relationship.Builder()
+            .name("Failure")
+            .description("Failed")
+            .build();
+
+    private List<PropertyDescriptor> descriptors;
+
+    private Set<Relationship> relationships;
+
+    @Override
+    protected void init(final ProcessorInitializationContext context) {
+        final List<PropertyDescriptor> descriptors = new ArrayList<PropertyDescriptor>();
+        descriptors.add(STORAGE_FILE_NAME);
+        this.descriptors = Collections.unmodifiableList(descriptors);
+
+        final Set<Relationship> relationships = new HashSet<Relationship>();
+        relationships.add(SUCCESS);
+        relationships.add(FAILURE);
+
+        this.relationships = Collections.unmodifiableSet(relationships);
+    }
+
+    @Override
+    public Set<Relationship> getRelationships() {
+        return this.relationships;
+    }
+
+    @Override
+    public final List<PropertyDescriptor> getSupportedPropertyDescriptors() {
+        return descriptors;
+    }
+
+    @OnScheduled
+    public void onScheduled(final ProcessContext context) {
+
+    }
+
+    @Override
+    public void onTrigger(final ProcessContext context, final ProcessSession session) throws ProcessException {
+        ComponentLog logger = getLogger();
+        FlowFile flowFile = session.get();
+
+        if ( flowFile == null ) {
+            logger.error("Flow file is null");
+            return;
+        }
+
+        HashSet<String> opcNodeList;
+
+        // Extract file path from property field
+        File filePath = new File(context.getProperty(STORAGE_FILE_NAME).getValue());
+        opcNodeList = readStorageFile(filePath);
+
+        // Initialize  response variable
+        final AtomicReference<String> opcJsonData = new AtomicReference<>();
+
+        // Read opc data from flow file content
+        session.read(flowFile, new InputStreamCallback() {
+            @Override
+            public void process(InputStream in) throws IOException {
+
+                try{
+                    String tagname = new BufferedReader(new InputStreamReader(in)).readLine();
+                    opcJsonData.set(tagname);
+                }catch (Exception e) {
+                    // TODO Auto-generated catch block
+                    e.printStackTrace();
+                    logger.error("Failed to read");
+                }
+            }
+        });
+
+        JsonNode jsonNode = null;
+        try {
+            jsonNode = mapper.readTree(opcJsonData.get());
+        } catch (IOException ex) {
+            logger.error("Error in parsing JSON string");
+            return;
+        }
+
+        Iterator<Map.Entry<String, JsonNode>> attributes = jsonNode.fields();
+        while (attributes.hasNext()) {
+            Map.Entry<String, JsonNode> attribute = attributes.next();
+            processAttribute(attribute, opcNodeList);
+        }
+
+        if (!opcNodeList.isEmpty()) {
+            final String outData = parseSetData(opcNodeList);
+            session.putAttribute(flowFile, "filename", filePath.getName());
+            flowFile = session.write(flowFile, out -> out.write(outData.getBytes()));
+            session.transfer(flowFile, SUCCESS);
+        } else {
+            logger.error("OPCUA Set is empty");
+            session.transfer(flowFile, FAILURE);
+        }
+    }
+
+    private HashSet<String> readStorageFile(File filePath) {
+        HashSet<String> opcNodeList = new HashSet<>();
+        try(BufferedReader br = new BufferedReader(new FileReader(filePath))) {
+            String currentLine;
+            while ((currentLine = br.readLine()) != null) {
+                opcNodeList.add(currentLine);
+            }
+        } catch (IOException ex) {
+            getLogger().info("Error in reading storage file or file doesn't exist");
+        }
+        return opcNodeList;
+    }
+
+    private void processAttribute(Map.Entry<String, JsonNode> attribute, HashSet<String> opcNodeList) {
+        if (attribute.getKey().equals("deleted")) {
+            removeDeletedAttributes(attribute.getValue(), opcNodeList);
+        } else if (!attribute.getValue().asBoolean()) {
+            opcNodeList.remove(attribute.getKey());
+        } else {
+            opcNodeList.add(attribute.getKey());
+        }
+    }
+
+    private void removeDeletedAttributes(JsonNode attrList, HashSet<String> opcNodeList) {
+        Iterator<JsonNode> iterator = attrList.elements();
+        while (iterator.hasNext()) {
+            JsonNode js = iterator.next();
+            opcNodeList.remove(js.textValue());
+        }
+    }
+
+    private String parseSetData(HashSet<String> opcNodeList) {
+        StringBuilder nodeListData = new StringBuilder();
+        Iterator<String> it = opcNodeList.iterator();
+        while (it.hasNext()) {
+            nodeListData.append(it.next() + System.getProperty("line.separator"));
+        }
+        return nodeListData.toString();
+    }
+}

--- a/nifi-tempus-processors/src/main/resources/META-INF/services/org.apache.nifi.processor.Processor
+++ b/nifi-tempus-processors/src/main/resources/META-INF/services/org.apache.nifi.processor.Processor
@@ -18,4 +18,5 @@ com.hashmapinc.tempus.nifi.processors.TelemetryToTempus
 com.hashmapinc.tempus.nifi.processors.LogToTempus
 com.hashmapinc.tempus.nifi.processors.TrajectoryToTempus
 com.hashmapinc.tempus.nifi.processors.OpcToTempusAttributes
+com.hashmapinc.tempus.nifi.processors.TempusToNodeList
 

--- a/nifi-tempus-processors/src/main/resources/META-INF/services/org.apache.nifi.processor.Processor
+++ b/nifi-tempus-processors/src/main/resources/META-INF/services/org.apache.nifi.processor.Processor
@@ -17,5 +17,5 @@ com.hashmapinc.tempus.nifi.processors.AttributesToTempus
 com.hashmapinc.tempus.nifi.processors.TelemetryToTempus
 com.hashmapinc.tempus.nifi.processors.LogToTempus
 com.hashmapinc.tempus.nifi.processors.TrajectoryToTempus
-
+com.hashmapinc.tempus.nifi.processors.OpcToTempusAttributes
 


### PR DESCRIPTION
1. Added a nifi processor OpcToTempusAttributes processor. The processor will read GetOPCNodeList Processor output. It convert the OPC data into Tempus attribute data.
2. Processor property will let us generate data in Tempus Gateway or Tempus Device attribute json format.
3. Tempus-138- added a processor to process shared attributes messages and convert them into OPC node list for GetOPCData processor